### PR TITLE
＃22 評価指標の算出

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ def main():
     a =  sample_XX_inv @ sample_X.T @ sample_y[:, np.newaxis]
     ## 求めた係数を用いて y の値を予測
     X = x[:, np.newaxis] ** p[np.newaxis, :]
-    y_pred = (X @ a)[:]
+    y_pred = np.squeeze(X @ a)
     # グラフの表示
     fig = Figure()
     ax = fig.add_subplot(1, 1, 1, xlabel='$x$', ylabel='$y$')

--- a/main.py
+++ b/main.py
@@ -20,6 +20,12 @@ def main():
     ## 求めた係数を用いて y の値を予測
     X = x[:, np.newaxis] ** p[np.newaxis, :]
     y_pred = np.squeeze(X @ a)
+    # 評価指標の算出
+    norm_y = np.sum(np.abs(y))
+    norm_diff = np.sum(np.abs(y - y_pred))
+    eps = 1e-8
+    score = norm_diff / (norm_y + eps)
+    print(f'{score = :.3f}')
     # グラフの表示
     fig = Figure()
     ax = fig.add_subplot(1, 1, 1, xlabel='$x$', ylabel='$y$')


### PR DESCRIPTION
- 評価指標はL1ノルムを使って ||t - y|| / ||t||+ε で実装した。
    - これにより関数を定数倍しても結果はほぼ同じ評価値になる。
- `y_pred`が1次元になっていなかった（縦ベクトル）ため1次元配列になるよう修正した。